### PR TITLE
[Ruby]Add Minimum Sigmoid

### DIFF
--- a/ruby/lib/sigmoid.rb
+++ b/ruby/lib/sigmoid.rb
@@ -1,0 +1,13 @@
+class Sigmoid
+  def forward(x)
+    1 / (1 + Numo::NMath.exp(-x))
+  end
+
+  def params
+    @params ||= []
+  end
+
+  def grads
+    @grads ||= []
+  end
+end


### PR DESCRIPTION
ruby版第１章のSigmoid実装となります。
（params, grads はただ配列を返すだけでも良かったかも、今後どう使うのか不明だったので一応インスタンス変数を設定できるようにしています）

```
% irb                                                                                                                                                                                                                          (git)-[master]
irb(main):001:0> require 'numo/narray'
=> true
irb(main):002:0> require './lib/sigmoid.rb'
=> true
irb(main):003:0> s = Sigmoid.new
=> #<Sigmoid:0x007f97769267a0>
irb(main):004:0> s.params
=> []
irb(main):005:0> s.grads
=> []
irb(main):006:0> s.forward(3)
=> Numo::DFloat#shape=[]
0.952574
```